### PR TITLE
Custom TextView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,4 +37,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+
+    implementation project(":textview")
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
-    <TextView
+    <com.course.textview.CustomTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:ctv_text="Some text should be here"
+        app:ctv_textSize="40"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,6 +12,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:ctv_text="Some text should be here"
-        app:ctv_textSize="40"/>
+        app:ctv_textSize="20sp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/textview/build.gradle
+++ b/textview/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/textview/src/main/java/com/course/textview/CustomTextView.kt
+++ b/textview/src/main/java/com/course/textview/CustomTextView.kt
@@ -1,0 +1,88 @@
+package com.course.textview
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.View
+import kotlin.math.min
+
+class CustomTextView(
+    context: Context,
+    attrs: AttributeSet
+) : View(context, attrs) {
+
+    private val attributes = context.theme.obtainStyledAttributes(
+        attrs,
+        R.styleable.CustomTextView,
+        0,
+        0
+    )
+    private val text = attributes.getString(R.styleable.CustomTextView_ctv_text)
+    private val attrsTextSize = attributes.getInt(R.styleable.CustomTextView_ctv_textSize, DEFAULT_TEXT_SIZE)
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        .apply {
+            color = Color.BLACK
+            textAlign = Paint.Align.LEFT
+            textSize = attrsTextSize * resources.displayMetrics.scaledDensity
+        }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        if (text == null) return
+
+        val desiredWidth = paint.measureText(text).toInt()
+        val desiredHeight = paint.getTextHeight(text)
+
+        val widthMode = MeasureSpec.getMode(widthMeasureSpec)
+        val heightMode = MeasureSpec.getMode(heightMeasureSpec)
+
+        val widthSize = MeasureSpec.getSize(widthMeasureSpec)
+        val heightSize = MeasureSpec.getSize(heightMeasureSpec)
+
+        val width = when (widthMode) {
+            MeasureSpec.EXACTLY -> widthSize
+            MeasureSpec.AT_MOST -> min(widthSize, desiredWidth)
+            else -> desiredWidth
+        }
+
+        val height = when (heightMode) {
+            MeasureSpec.EXACTLY -> heightSize
+            MeasureSpec.AT_MOST -> min(heightSize, desiredHeight)
+            else -> desiredHeight
+        }
+
+        // To avoid issues in layout preview
+        if (width < 0 || height < 0) return
+
+        setMeasuredDimension(width, height)
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        if (canvas == null || text == null) return
+
+        canvas.drawText(
+            text,
+            0F,
+            paint.getTextBaseline(text),
+            paint
+        )
+    }
+
+    private fun Paint.getTextHeight(text: String): Int {
+        return (getTextBaseline(text) + fontMetrics.bottom).toInt()
+    }
+
+    private fun Paint.getTextBaseline(text: String): Float {
+        val textBounds = Rect()
+        getTextBounds(text, 0, text.length, textBounds)
+
+        return textBounds.height().toFloat()
+    }
+
+    companion object {
+        private const val DEFAULT_TEXT_SIZE = 20
+    }
+}

--- a/textview/src/main/java/com/course/textview/CustomTextView.kt
+++ b/textview/src/main/java/com/course/textview/CustomTextView.kt
@@ -51,7 +51,7 @@ class CustomTextView(
                 try {
                     parameters = parameters.copy(
                         text = getString(R.styleable.CustomTextView_ctv_text),
-                        textSize = getInt(
+                        textSize = getDimensionPixelSize(
                             R.styleable.CustomTextView_ctv_textSize,
                             DEFAULT_TEXT_SIZE
                         ),
@@ -70,7 +70,7 @@ class CustomTextView(
         color = Color.BLACK
         textAlign = Paint.Align.LEFT
         typeface = getFontSafely(fontRes = parameters.font)
-        textSize = parameters.textSize * resources.displayMetrics.scaledDensity
+        textSize = parameters.textSize.toFloat()
     }
 
     private var staticLayout: StaticLayout by notNull()

--- a/textview/src/main/java/com/course/textview/CustomTextView.kt
+++ b/textview/src/main/java/com/course/textview/CustomTextView.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import android.view.View
 import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.content.withStyledAttributes
 import kotlinx.parcelize.Parcelize
 import kotlin.properties.Delegates.notNull
 
@@ -41,29 +42,23 @@ class CustomTextView(
     )
 
     init {
-        context.theme.obtainStyledAttributes(
+        context.withStyledAttributes(
             attrs,
             R.styleable.CustomTextView,
-            0,
             0
-        )
-            .apply {
-                try {
-                    parameters = parameters.copy(
-                        text = getString(R.styleable.CustomTextView_ctv_text),
-                        textSize = getDimensionPixelSize(
-                            R.styleable.CustomTextView_ctv_textSize,
-                            DEFAULT_TEXT_SIZE
-                        ),
-                        font = getResourceId(
-                            R.styleable.CustomTextView_ctv_font,
-                            RESOURCE_NOT_FOUND
-                        )
-                    )
-                } finally {
-                    recycle()
-                }
-            }
+        ) {
+            parameters = parameters.copy(
+                text = getString(R.styleable.CustomTextView_ctv_text),
+                textSize = getDimensionPixelSize(
+                    R.styleable.CustomTextView_ctv_textSize,
+                    DEFAULT_TEXT_SIZE
+                ),
+                font = getResourceId(
+                    R.styleable.CustomTextView_ctv_font,
+                    RESOURCE_NOT_FOUND
+                )
+            )
+        }
     }
 
     private val textPaint = TextPaint().apply {

--- a/textview/src/main/java/com/course/textview/CustomTextView.kt
+++ b/textview/src/main/java/com/course/textview/CustomTextView.kt
@@ -35,24 +35,9 @@ class CustomTextView(
 
         val desiredWidth = paint.measureText(text).toInt()
         val desiredHeight = paint.getTextHeight(text)
-
-        val widthMode = MeasureSpec.getMode(widthMeasureSpec)
-        val heightMode = MeasureSpec.getMode(heightMeasureSpec)
-
-        val widthSize = MeasureSpec.getSize(widthMeasureSpec)
-        val heightSize = MeasureSpec.getSize(heightMeasureSpec)
-
-        val width = when (widthMode) {
-            MeasureSpec.EXACTLY -> widthSize
-            MeasureSpec.AT_MOST -> min(widthSize, desiredWidth)
-            else -> desiredWidth
-        }
-
-        val height = when (heightMode) {
-            MeasureSpec.EXACTLY -> heightSize
-            MeasureSpec.AT_MOST -> min(heightSize, desiredHeight)
-            else -> desiredHeight
-        }
+        
+        val width = resolveSize(desiredWidth, widthMeasureSpec)
+        val height = resolveSize(desiredHeight, heightMeasureSpec)
 
         // To avoid issues in layout preview
         if (width < 0 || height < 0) return

--- a/textview/src/main/java/com/course/textview/CustomTextView.kt
+++ b/textview/src/main/java/com/course/textview/CustomTextView.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.os.Parcelable
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.view.View
+import kotlinx.parcelize.Parcelize
 import kotlin.properties.Delegates.notNull
 
 class CustomTextView(
@@ -15,47 +17,97 @@ class CustomTextView(
     attrs: AttributeSet
 ) : View(context, attrs) {
 
-    private val attributes = context.theme.obtainStyledAttributes(
-        attrs,
-        R.styleable.CustomTextView,
-        0,
-        0
+    @Parcelize
+    private data class Parameters(
+        val text: String?,
+        val textSize: Int
+    ) : Parcelable
+
+    @Parcelize
+    private data class SaveState(
+        val superSavedState: Parcelable?,
+        val parameters: Parameters
+    ) : View.BaseSavedState(superSavedState), Parcelable
+
+    private var parameters: Parameters = Parameters(
+        text = null,
+        textSize = DEFAULT_TEXT_SIZE
     )
-    private val text = attributes.getString(R.styleable.CustomTextView_ctv_text)
-    private val attrsTextSize =
-        attributes.getInt(R.styleable.CustomTextView_ctv_textSize, DEFAULT_TEXT_SIZE)
+
+    init {
+        context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.CustomTextView,
+            0,
+            0
+        )
+            .apply {
+                try {
+                    parameters = parameters.copy(
+                        text = getString(R.styleable.CustomTextView_ctv_text),
+                        textSize = getInt(R.styleable.CustomTextView_ctv_textSize, DEFAULT_TEXT_SIZE)
+                    )
+                } finally {
+                    recycle()
+                }
+            }
+    }
 
     private val textPaint = TextPaint().apply {
         color = Color.BLACK
         textAlign = Paint.Align.LEFT
-        textSize = attrsTextSize * resources.displayMetrics.scaledDensity
+        textSize = parameters.textSize * resources.displayMetrics.scaledDensity
     }
 
     private var staticLayout: StaticLayout by notNull()
 
+    override fun onSaveInstanceState(): Parcelable {
+        return SaveState(
+            superSavedState = super.onSaveInstanceState(),
+            parameters = parameters
+        )
+    }
 
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val savedState = state as? SaveState
+        super.onRestoreInstanceState(savedState?.superSavedState ?: state)
+
+        savedState ?: return
+        parameters = savedState.parameters
+    }
+    
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        if (text == null) return
+        if (parameters.text == null) {
+            setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
+            return
+        } else {
+            val text = requireNotNull(parameters.text)
 
-        val desiredWidth = textPaint.measureText(text).toInt()
+            val measuredWidth = textPaint.measureText(text).toInt()
 
-        val width = resolveSize(desiredWidth, widthMeasureSpec)
-        staticLayout = StaticLayout.Builder
-            .obtain(text, 0, text.length, textPaint, width)
-            .build()
+            val width = resolveSize(measuredWidth, widthMeasureSpec)
+            staticLayout = StaticLayout.Builder
+                .obtain(text, 0, text.length, textPaint, width)
+                .build()
 
-        val height = resolveSize(staticLayout.height, heightMeasureSpec)
+            val height = resolveSize(staticLayout.height, heightMeasureSpec)
 
-        // To avoid issues in layout preview
-        if (width < 0 || height < 0) return
-
-        setMeasuredDimension(width, height)
+            setMeasuredDimension(width, height)
+        }
     }
 
     override fun onDraw(canvas: Canvas?) {
-        if (canvas == null || text == null) return
+        if (canvas == null || parameters.text == null) return
 
         staticLayout.draw(canvas)
+    }
+
+    fun setText(text: String) {
+        parameters = parameters.copy(
+            text = text
+        )
+        requestLayout()
+        invalidate()
     }
 
     companion object {

--- a/textview/src/main/res/values/attrs.xml
+++ b/textview/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="CustomTextView">
+        <attr name="ctv_text" format="string"/>
+        <attr name="ctv_textSize" format="integer"/>
+    </declare-styleable>
+
+</resources>

--- a/textview/src/main/res/values/attrs.xml
+++ b/textview/src/main/res/values/attrs.xml
@@ -3,7 +3,7 @@
 
     <declare-styleable name="CustomTextView">
         <attr name="ctv_text" format="string"/>
-        <attr name="ctv_textSize" format="integer"/>
+        <attr name="ctv_textSize" format="dimension"/>
         <attr name="ctv_font" format="reference"/>
     </declare-styleable>
 

--- a/textview/src/main/res/values/attrs.xml
+++ b/textview/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
     <declare-styleable name="CustomTextView">
         <attr name="ctv_text" format="string"/>
         <attr name="ctv_textSize" format="integer"/>
+        <attr name="ctv_font" format="reference"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
This Custom TextView supports following features:

+ `wrap_content`, `match_parent` modes for width and height
+ `ctv_text` attribute (can be changed in runtime)
+ `ctv_textSize` attribute in sp (can only be set through xml)
+ saving state of view (using `SavedState`)
+ `ctv_font` attribute for setting text font (can only be set through xml)

The whole thing can be tested with the help of testing branch -> https://github.com/Lonexera/custom_views/tree/testing

Known issue - "bfeskoosd" text can be truncated a little in width when displayed with font